### PR TITLE
Pagination support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ladda-react",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "React bindings for Ladda",
   "main": "dist/bundle.js",
   "dependencies": {},

--- a/src/hocs/withData/index.js
+++ b/src/hocs/withData/index.js
@@ -49,14 +49,14 @@ class Retriever {
 }
 
 class ResolveRetriever extends Retriever {
-  constructor({ name, getter, getProps, publishData, publishError }) {
-    super({ type: 'resolve', name, getter, getProps, publishData, publishError });
+  constructor(args) {
+    super({ type: 'resolve', ...args });
   }
 }
 
 class ObserveRetriever extends Retriever {
-  constructor({ name, getter, getProps, publishData, publishError }) {
-    super({ type: 'observe', name, getter, getProps, publishData, publishError });
+  constructor(args) {
+    super({ type: 'observe', ...args });
 
     this.subscription = null;
   }
@@ -86,8 +86,8 @@ const mergePaginateProps = (props, name, obj) => ({
 });
 
 class PaginatedInfiniteOffsetAndLimitResolveRetriever extends Retriever {
-  constructor({ name, getter, getProps, publishData, publishError, pagerConfig }) {
-    super({ type: 'resolve paginated', name, getter, getProps, publishData, publishError });
+  constructor({ pagerConfig, ...args }) {
+    super({ type: 'resolve paginated', ...args });
     this.pagerConfig = pagerConfig;
 
     this.pagers = [];
@@ -120,8 +120,8 @@ class PaginatedInfiniteOffsetAndLimitResolveRetriever extends Retriever {
 }
 
 class PaginatedInfiniteOffsetAndLimitObserveRetriever extends Retriever {
-  constructor({ name, getter, getProps, publishData, publishError, pagerConfig }) {
-    super({ type: 'observe paginated', name, getter, getProps, publishData, publishError });
+  constructor({ pagerConfig, ...args }) {
+    super({ type: 'observe paginated', ...args });
     this.pagerConfig = pagerConfig;
 
     this.pagerSubscriptions = [];
@@ -154,7 +154,6 @@ class PaginatedInfiniteOffsetAndLimitObserveRetriever extends Retriever {
     return Promise.resolve();
   }
 
-  // add pager object, without subscription
   queueNext() {
     const pagers = this.pagerSubscriptions.map((p) => p.pager);
     const prevPager = pagers[pagers.length - 1] || { limit: null, offset: null };

--- a/src/hocs/withData/index.js
+++ b/src/hocs/withData/index.js
@@ -78,6 +78,14 @@ class ObserveRetriever extends Retriever {
   }
 }
 
+const mergePaginateProps = (props, name, obj) => ({
+  ...props,
+  paginate: {
+    ...props.paginate,
+    [name]: obj
+  }
+});
+
 class PaginatedInfiniteOffsetAndLimitResolveRetriever extends Retriever {
   constructor({ name, getter, getProps, publishData, publishError, pagerConfig }) {
     super({ type: 'resolve paginated', name, getter, getProps, publishData, publishError });
@@ -103,24 +111,18 @@ class PaginatedInfiniteOffsetAndLimitResolveRetriever extends Retriever {
   }
 
   mergeProps(props) {
-    return {
-      ...props,
-      paginate: {
-        ...props.paginate,
-        [this.name]: {
-          getNext: () => {
-            this.queueNext();
-            return this.get();
-          }
-        }
+    return mergePaginateProps(props, this.name, {
+      getNext: () => {
+        this.queueNext();
+        return this.get();
       }
-    };
+    });
   }
 }
 
 class PaginatedInfiniteOffsetAndLimitObserveRetriever extends Retriever {
   constructor({ name, getter, getProps, publishData, publishError, pagerConfig }) {
-    super({ type: 'resolve paginated', name, getter, getProps, publishData, publishError });
+    super({ type: 'observe paginated', name, getter, getProps, publishData, publishError });
     this.pagerConfig = pagerConfig;
 
     this.pagerSubscriptions = [];
@@ -168,18 +170,12 @@ class PaginatedInfiniteOffsetAndLimitObserveRetriever extends Retriever {
   }
 
   mergeProps(props) {
-    return {
-      ...props,
-      paginate: {
-        ...props.paginate,
-        [this.name]: {
-          getNext: () => {
-            this.queueNext();
-            return this.get();
-          }
-        }
+    return mergePaginateProps(props, this.name, {
+      getNext: () => {
+        this.queueNext();
+        return this.get();
       }
-    };
+    });
   }
 
   onDestroy() {

--- a/src/hocs/withData/index.js
+++ b/src/hocs/withData/index.js
@@ -131,21 +131,10 @@ class PaginatedInfiniteOffsetAndLimitObserveRetriever extends Retriever {
 
   get() {
     const props = this.getProps();
-    const tryToPublish = () => {
-      const result = [];
-      for (let i = 0; i < this.pagerSubscriptions.length; i++) {
-        const p = this.pagerSubscriptions[i];
-        if (!p.data) {
-          return;
-        }
-        result.push(...p.data);
-      }
-      this.publishData(result);
-    };
     this.pagerSubscriptions = this.pagerSubscriptions.map((p) => {
       if (!p.subscription) {
         p.subscription = this.getter(props, p.pager).subscribe(
-          (data) => { p.data = data; tryToPublish(); },
+          (data) => { p.data = data; this.tryToPublish(); },
           this.publishError
         );
       }
@@ -165,6 +154,18 @@ class PaginatedInfiniteOffsetAndLimitObserveRetriever extends Retriever {
       error: null
     };
     this.pagerSubscriptions.push(p);
+  }
+
+  tryToPublish() {
+    const result = [];
+    for (let i = 0; i < this.pagerSubscriptions.length; i++) {
+      const p = this.pagerSubscriptions[i];
+      if (!p.data) {
+        return;
+      }
+      result.push(...p.data);
+    }
+    this.publishData(result);
   }
 
   mergeProps(props) {


### PR DESCRIPTION
We can now opt into a pagination mode when using `withData`.

Pagination can come in different forms - e.g. one might want really want 10 items per page, then the next ten items and the next ten times, or it's used in an infinite scrolling environment where you want the first ten, then 20 etc...

`withData` makes sure that based on your setting the correct data is passed down to your component. Observing also works.

A low level API to define what paging means is exposed. The idea is to provide various presets, so that this is straightforward to use.
Right now one preset is provided: Using pagination with offset and limit parameters for an infinte scrolling environment. The component makes sure that the offset and limit params are correctly handled - they are then passed to the api function at the right time.