### PR TITLE
shouldRefetch and unmount guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "files": ["dist/module.js"],
   "dependencies": {},
   "peerDependencies": {
-    "react": "^16.0.0"
+    "react": "^15.6.0 || ^16.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ladda-react",
-  "version": "0.2.13",
+  "version": "0.2.14",
   "description": "React bindings for Ladda",
   "main": "dist/bundle.js",
   "module": "dist/module.js",

--- a/src/hocs/withData/index.js
+++ b/src/hocs/withData/index.js
@@ -368,13 +368,16 @@ class Container extends Component {
     this.destroy();
   }
 
+  safeSetState(...args) {
+    if (!this.isUnmounting) {
+      this.setState(...args);
+    }
+  }
+
   addResolvedData(field, data) {
     this.resolvedData[field] = data;
-    if (this.isUnmounting) {
-      return;
-    }
     if (this.resolvedDataTargetSize === Object.keys(this.resolvedData).length) {
-      this.setState({
+      this.safeSetState({
         pending: false,
         resolvedProps: { ...this.resolvedData },
         error: null
@@ -383,7 +386,7 @@ class Container extends Component {
   }
 
   setError(field, error) {
-    this.setState({ pending: false, error });
+    this.safeSetState({ pending: false, error });
   }
 
   setupRetrievers(props) {
@@ -439,7 +442,7 @@ class Container extends Component {
   }
 
   trigger() {
-    this.setState({ pending: true, error: null });
+    this.safeSetState({ pending: true, error: null });
 
     Object.keys(this.retrievers).forEach((key) => {
       this.retrievers[key].get();

--- a/src/hocs/withData/index.js
+++ b/src/hocs/withData/index.js
@@ -332,6 +332,8 @@ class Container extends Component {
     this.subscriptions = [];
     this.pagers = {};
 
+    this.isUnmounting = false;
+
     this.state = {
       pending: false,
       error: null,
@@ -362,11 +364,15 @@ class Container extends Component {
   }
 
   componentWillUnmount() {
+    this.isUnmounting = true;
     this.destroy();
   }
 
   addResolvedData(field, data) {
     this.resolvedData[field] = data;
+    if (this.isUnmounting) {
+      return;
+    }
     if (this.resolvedDataTargetSize === Object.keys(this.resolvedData).length) {
       this.setState({
         pending: false,

--- a/src/hocs/withData/index.js
+++ b/src/hocs/withData/index.js
@@ -352,6 +352,10 @@ class Container extends Component {
   }
 
   componentWillReceiveProps(newProps) {
+    const { shouldRefetch = (() => true) } = newProps;
+    if (!shouldRefetch(this.props.originalProps, newProps.originalProps)) {
+      return;
+    }
     this.destroy();
     this.setupRetrievers(newProps);
     this.trigger();

--- a/src/hocs/withData/index.spec.js
+++ b/src/hocs/withData/index.spec.js
@@ -74,8 +74,12 @@ const createSpyComponent = () => {
 };
 
 class StateContainer extends Component {
+  constructor(props) {
+    super(props);
+    this.state = props.componentProps;
+  }
   render() {
-    return createElement(this.props.component, { ...this.props.componentProps, ...this.state });
+    return createElement(this.props.component, { ...this.state });
   }
 }
 

--- a/src/hocs/withData/index.spec.js
+++ b/src/hocs/withData/index.spec.js
@@ -316,5 +316,42 @@ describe('withData', () => {
       });
     });
   });
+
+  describe('shouldRefetch', () => {
+    it('does not trigger callbacks when returning false for new props', () => {
+      const spy = createSpyComponent();
+      const spyResolve = sinon.stub().returns(Promise.resolve({}));
+
+      const comp = withData({
+        resolve: {
+          user: ({ userId }) => spyResolve(userId)
+        },
+        shouldRefetch: (props, nextProps) => {
+          return props.userId === 'robin' && nextProps.userId === 'gernot';
+        }
+      })(spy);
+
+      let stateContainer = null;
+
+      render(comp, { userId: 'peter' }, c => { stateContainer = c; });
+
+      return delay().then(() => {
+        expect(spy).to.have.been.calledOnce;
+        expect(spyResolve).to.have.been.calledOnce;
+
+        stateContainer.setState({ userId: 'robin' });
+        return delay().then(() => {
+          expect(spyResolve).to.have.been.calledOnce;
+          expect(spy).to.have.been.calledTwice;
+
+          stateContainer.setState({ userId: 'gernot' });
+          return delay().then(() => {
+            expect(spyResolve).to.have.been.calledTwice;
+            expect(spy).to.have.been.calledThrice;
+          });
+        });
+      });
+    });
+  });
 });
 

--- a/src/hocs/withData/index.spec.js
+++ b/src/hocs/withData/index.spec.js
@@ -1,5 +1,5 @@
 /* eslint-disable no-unused-expressions */
-import { createElement } from 'react';
+import { Component, createElement } from 'react';
 import ReactTestUtils from 'react-dom/test-utils'; // ES6
 import { build } from 'ladda-cache';
 import { observable } from 'ladda-observable';
@@ -73,9 +73,15 @@ const createSpyComponent = () => {
   return sinon.stub().returns(null);
 };
 
-const render = (component, props) => {
-  const el = createElement(component, props);
-  return ReactTestUtils.renderIntoDocument(el);
+class StateContainer extends Component {
+  render() {
+    return createElement(this.props.component, { ...this.props.componentProps, ...this.state });
+  }
+}
+
+const render = (component, componentProps, ref) => {
+  const c = () => createElement(StateContainer, { ref, component, componentProps });
+  return ReactTestUtils.renderIntoDocument(createElement(c));
 };
 
 describe('withData', () => {


### PR DESCRIPTION
Adds the additional feature of passing a `shouldRefetch` function to the `withData` config. This function is passed oldProps and nextProps - when it returns false all resolvers, observers and pollers will not be re-triggered.

Also fixes the unmount problem, where `setState` could be called after the component already unmounted (because a promise only resolved after this happened). Was originally contributed by @herrherrmann in #2 - the commit was cherry picked and made more robust afterwards.