### PR TITLE
Make withData a PureComponent (again)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ladda-react",
-  "version": "0.2.14",
+  "version": "0.2.15",
   "description": "React bindings for Ladda",
   "main": "dist/bundle.js",
   "module": "dist/module.js",

--- a/src/hocs/withData/index.js
+++ b/src/hocs/withData/index.js
@@ -1,4 +1,4 @@
-import { createElement, Component } from 'react';
+import { createElement, Component, PureComponent } from 'react';
 
 const PAGINATION = {
   TYPE: {
@@ -471,11 +471,13 @@ class Container extends Component {
 
 export function withData(conf) {
   return component => {
-    // make it pure again
-    return (originalProps) => {
-      const props = { ...conf, originalProps, component };
-      return createElement(Container, props);
-    };
+    class WithDataWrapper extends PureComponent {
+      render() {
+        const props = { ...conf, originalProps: this.props, component };
+        return createElement(Container, props);
+      }
+    }
+    return WithDataWrapper;
   };
 }
 


### PR DESCRIPTION
`withData` was always intended to be pure (and used to be, in versions before this repo existed). For some reason the pure check was taken out while developing this further - and a comment left behind to make it pure again.

Here we go! We highly suspect that no one relied on this behavior so far. It can actually cause problems, so maybe people tried to work around this even, which would not be necessary anymore now.